### PR TITLE
Implement initial Lisp interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,24 @@ This project aims to build a small interpreter for a toy ML-like language. The l
 - Hindley–Milner type inference with `let` polymorphism
 - Call-by-value evaluation strategy
 
-The entire system is implemented in OCaml. The front end compiles TestML code to S-expressions and the back end runs those expressions using a minimalist Lisp interpreter. A small REPL is planned for interactive testing.
+The entire system is implemented in OCaml. The front end will eventually compile
+TestML code to S-expressions, which are then evaluated by a minimalist Lisp
+interpreter. A small REPL is planned for interactive testing.  At this early
+stage only the S-expression interpreter is available.
+
+## Building
+
+The project uses `dune` for building.  To compile the interpreter run:
+
+```bash
+dune build
+```
+
+You can then execute the interpreter with:
+
+```bash
+dune exec testml "( + 1 2 )"
+```
+
+Without a command line argument the program starts a very small REPL that reads
+a single S-expression from standard input.

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.6)
+(name testml)
+

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,4 @@
+(executable
+ (name main)
+ (public_name testml)
+ (modules sexp sexp_parser lisp main))

--- a/src/lisp.ml
+++ b/src/lisp.ml
@@ -1,0 +1,45 @@
+open Sexp
+
+(* Simple value type for the interpreter *)
+type value =
+  | Int of int
+  | Bool of bool
+  | List of value list
+  | Symbol of string
+
+exception Runtime_error of string
+
+let rec value_to_string = function
+  | Int n -> string_of_int n
+  | Bool b -> string_of_bool b
+  | List xs -> "(" ^ String.concat " " (List.map value_to_string xs) ^ ")"
+  | Symbol s -> s
+
+let as_int = function
+  | Int n -> n
+  | _ -> raise (Runtime_error "expected int")
+
+let as_bool = function
+  | Bool b -> b
+  | _ -> raise (Runtime_error "expected bool")
+
+let apply_builtin op args =
+  match op, args with
+  | "+", [Int a; Int b] -> Int (a + b)
+  | "-", [Int a; Int b] -> Int (a - b)
+  | "*", [Int a; Int b] -> Int (a * b)
+  | "/", [Int a; Int b] -> Int (a / b)
+  | "not", [Bool b] -> Bool (not b)
+  | "and", [Bool a; Bool b] -> Bool (a && b)
+  | "or", [Bool a; Bool b] -> Bool (a || b)
+  | _ -> raise (Runtime_error ("unknown builtin " ^ op))
+
+let rec eval = function
+  | Atom s -> (
+      try Int (int_of_string s) with Failure _ -> Symbol s)
+  | List (Atom op :: args) ->
+      let args = List.map eval args in
+      apply_builtin op args
+  | List lst -> List (List.map eval lst)
+
+let print v = print_endline (value_to_string v)

--- a/src/main.ml
+++ b/src/main.ml
@@ -1,0 +1,18 @@
+open Sexp_parser
+open Lisp
+
+let () =
+  let input =
+    if Array.length Sys.argv > 1 then
+      Sys.argv.(1)
+    else (
+      print_string "> ";
+      read_line ()
+    )
+  in
+  match parse input with
+  | Ok sexp ->
+      let result = eval sexp in
+      print result
+  | Error msg ->
+      prerr_endline ("Parse error: " ^ msg)

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -1,0 +1,8 @@
+type t =
+  | Atom of string
+  | List of t list
+
+let rec to_string = function
+  | Atom s -> s
+  | List xs ->
+      "(" ^ String.concat " " (List.map to_string xs) ^ ")"

--- a/src/sexp_parser.ml
+++ b/src/sexp_parser.ml
@@ -1,0 +1,46 @@
+open Sexp
+
+exception Parse_error of string
+
+let is_whitespace = function ' ' | '\t' | '\n' | '\r' -> true | _ -> false
+
+let tokenize s =
+  let buf = Buffer.create 16 in
+  let tokens = ref [] in
+  let push tok = tokens := tok :: !tokens in
+  let flush_atom () =
+    if Buffer.length buf > 0 then (
+      push (Buffer.contents buf);
+      Buffer.clear buf)
+  in
+  String.iter
+    (fun c ->
+      match c with
+      | '(' | ')' as ch ->
+          flush_atom (); push (String.make 1 ch)
+      | c when is_whitespace c -> flush_atom ()
+      | c -> Buffer.add_char buf c)
+    s;
+  flush_atom (); List.rev !tokens
+
+let parse s =
+  let tokens = tokenize s in
+  let rec parse_list acc = function
+    | [] -> raise (Parse_error "unexpected end of input")
+    | ")" :: rest -> (List (List.rev acc), rest)
+    | "(" :: rest ->
+        let inner, rest' = parse_list [] rest in
+        parse_list (inner :: acc) rest'
+    | tok :: rest -> parse_list (Atom tok :: acc) rest
+  in
+  let rec parse_top = function
+    | [] -> Error "empty input"
+    | "(" :: rest ->
+        let sexp, rest' = parse_list [] rest in
+        if rest' = [] then
+          Ok sexp
+        else
+          Error "unexpected tokens after expression"
+    | tok :: _ -> Ok (Atom tok)
+  in
+  parse_top tokens


### PR DESCRIPTION
## Summary
- add dune project files
- implement simple S-expression types and parser
- build minimal Lisp interpreter and command-line entry
- document how to build and run

## Testing
- `dune build` *(fails: command not found)*